### PR TITLE
Centralize Red Pitaya credentials in WiFi examples

### DIFF
--- a/examples/Wifi/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
+++ b/examples/Wifi/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
@@ -6,11 +6,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // -------- User config --------
-IPAddress RP_IP(192, 168, 0, 17);
-const uint16_t RP_PORT = 5000;
 
 const float FREQ_HZ   = 10000.0;  // both channels
 const float AMP_V     = 1.0;      // one-way amplitude
@@ -45,7 +43,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -58,7 +56,7 @@ void loop() {
   // Optional keep-alive / auto-restart
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) startTwoSineWithPhase();
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startTwoSineWithPhase();
   }
   delay(500);
 }

--- a/examples/Wifi/2ChannelPhaseShiftWifi/arduino_secrets.h
+++ b/examples/Wifi/2ChannelPhaseShiftWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AcquiireWifi/arduino_secrets.h
+++ b/examples/Wifi/AcquiireWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AcquireNowRawWifi/AcquireNowRawWifi.ino
+++ b/examples/Wifi/AcquireNowRawWifi/AcquireNowRawWifi.ino
@@ -2,10 +2,8 @@
    acquire_full_buffer_raw: force trigger and read full buffer as RAW ASCII codes
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -28,7 +26,7 @@ void printFirst(const String& blk, uint8_t n=12){
 void setup(){
   Serial.begin(115200);
   delay(200);
-  rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT);
+  rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
 
   rp.scpi("ACQ:RST");
   rp.scpi("ACQ:DEC:Factor 1");

--- a/examples/Wifi/AcquireNowRawWifi/arduino_secrets.h
+++ b/examples/Wifi/AcquireNowRawWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AcquireNowWifi/AcquireNowWifi.ino
+++ b/examples/Wifi/AcquireNowWifi/AcquireNowWifi.ino
@@ -2,10 +2,8 @@
    acquire_trigger_now: force trigger and read CH1 (ASCII/VOLTS)
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -18,7 +16,7 @@ void printFirst(const String& blk, uint8_t n=12){
 
 void setup(){
   Serial.begin(115200); delay(200);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }

--- a/examples/Wifi/AcquireNowWifi/arduino_secrets.h
+++ b/examples/Wifi/AcquireNowWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
+++ b/examples/Wifi/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
@@ -5,10 +5,8 @@
    - fire generator INT trigger to produce the edge
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -21,7 +19,7 @@ void printFirst(const String& blk, uint8_t n=12){
 
 void setup(){
   Serial.begin(115200); delay(200);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }

--- a/examples/Wifi/AcquireTriggerFromGenWifi/arduino_secrets.h
+++ b/examples/Wifi/AcquireTriggerFromGenWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/AnalogReadWifi/AnalogReadWifi.ino
+++ b/examples/Wifi/AnalogReadWifi/AnalogReadWifi.ino
@@ -5,10 +5,8 @@
 
 #include "wifiSCPI.h"
 #include <math.h>
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192, 168, 0, 17);
-const uint16_t RP_PORT = 5000;
 
 int   ARB_NPTS     = 2048;
 float F0_HZ        = 1000.0;
@@ -59,7 +57,7 @@ bool uploadSum3SinesOut1(int N) {
 void setup() {
   Serial.begin(115200);
   delay(150);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)) {
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)) {
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -70,7 +68,7 @@ void setup() {
 void loop() {
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) uploadSum3SinesOut1(ARB_NPTS);
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) uploadSum3SinesOut1(ARB_NPTS);
   }
   delay(500);
 }

--- a/examples/Wifi/AnalogReadWifi/arduino_secrets.h
+++ b/examples/Wifi/AnalogReadWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/ArbSignalWifi/ArbSignalWifi.ino
+++ b/examples/Wifi/ArbSignalWifi/ArbSignalWifi.ino
@@ -6,12 +6,10 @@
 
 #include "wifiSCPI.h"
 #include <math.h>
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 /************ User Config ************/
 // Red Pitaya SCPI server
-IPAddress RP_IP(192, 168, 0, 17);
-const uint16_t RP_PORT = 5000;
 
 // ARB buffer size (use 2048 for speed; 16384 is the full period size)
 int   ARB_NPTS     = 2048;
@@ -87,7 +85,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -102,7 +100,7 @@ void loop() {
   // Keep the link healthy (optional)
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) uploadSum3SinesOut1(ARB_NPTS); // re-arm after reconnect
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) uploadSum3SinesOut1(ARB_NPTS); // re-arm after reconnect
   }
   delay(500);
 }

--- a/examples/Wifi/ArbSignalWifi/arduino_secrets.h
+++ b/examples/Wifi/ArbSignalWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/BurstSignalWifi/BurstSignalWifi.ino
+++ b/examples/Wifi/BurstSignalWifi/BurstSignalWifi.ino
@@ -16,11 +16,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"  // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ---------- User config ----------
-IPAddress RP_IP(192, 168, 0, 17);   // your Red Pitaya IP
-const uint16_t RP_PORT = 5000;      // SCPI port
 
 // Signal settings
 const float FREQ_HZ   = 10e3;       // sine frequency
@@ -59,7 +57,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -72,7 +70,7 @@ void loop() {
   // Optional keep-alive
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) startBurst();
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startBurst();
   }
   delay(500);
 }

--- a/examples/Wifi/BurstSignalWifi/arduino_secrets.h
+++ b/examples/Wifi/BurstSignalWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/DMAAcquireWifi/DMAAcquireNowWifi.ino
+++ b/examples/Wifi/DMAAcquireWifi/DMAAcquireNowWifi.ino
@@ -2,10 +2,8 @@
    dma/acquire_dma_trigger_now: set AXI DMA, trigger NOW, read 1024 samples near trig (ASCII)
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -19,7 +17,7 @@ void printFirst(const String& blk, uint8_t n=12){
 
 void setup(){
   Serial.begin(115200); delay(200);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }

--- a/examples/Wifi/DMAAcquireWifi/DMAAcquireWifi.ino
+++ b/examples/Wifi/DMAAcquireWifi/DMAAcquireWifi.ino
@@ -5,10 +5,8 @@
    - fire generator INT trigger to produce the edge
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -21,7 +19,7 @@ void printFirst(const String& blk, uint8_t n=12){
 
 void setup(){
   Serial.begin(115200); delay(200);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }

--- a/examples/Wifi/DMAAcquireWifi/arduino_secrets.h
+++ b/examples/Wifi/DMAAcquireWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/GenSineWifi/GenSineWifi.ino
+++ b/examples/Wifi/GenSineWifi/GenSineWifi.ino
@@ -3,11 +3,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ---------- User config ----------
-IPAddress RP_IP(192, 168, 0, 17);  // <-- your Red Pitaya IP
-const uint16_t RP_PORT = 5000;     // SCPI server port
 
 // Sine parameters
 const float SINE_FREQ_HZ = 2000.0; // frequency
@@ -32,7 +30,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -45,7 +43,7 @@ void setup() {
 void loop() {
   // Keep connection alive (optional)
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
-  if (!rp.connected()) rp.connectRP(RP_IP, RP_PORT);
+  if (!rp.connected()) rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT);
   delay(500);
 }
 

--- a/examples/Wifi/GenSineWifi/arduino_secrets.h
+++ b/examples/Wifi/GenSineWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/examples/Wifi/PWMWifi/PWMWifi.ino
+++ b/examples/Wifi/PWMWifi/PWMWifi.ino
@@ -1,12 +1,10 @@
 #include <WiFiS3.h>
 #include "SCPI_RP.h"
 #include "SCPI_WiFi.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ------- User config -------
 #define USE_STATIC_IP  1
-IPAddress RP_IP(192, 168, 0, 17);
-const uint16_t RP_PORT = 5000;
 
 const float GEN_FREQ_HZ   = 2000.0;
 const float GEN_AMPL_V    = 1.0;
@@ -47,7 +45,7 @@ void setup() {
   }
   Serial.print("✅ WiFi OK, IP = "); Serial.println(net.localIP());
 
-  if (!net.connectRP(RP_IP, RP_PORT)) {
+  if (!net.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) {
     Serial.println("❌ TCP connect failed (will retry in loop)");
   } else {
     Serial.println("✅ TCP connected");
@@ -65,7 +63,7 @@ void loop() {
 #if USE_STATIC_IP
     cfg.useStaticIP = true; cfg.localIP = LOCAL_IP; cfg.gateway = GATEWAY; cfg.subnet = SUBNET; cfg.dns = DNS;
 #endif
-    if (net.ensureConnections(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT, &cfg)) {
+    if (net.ensureConnections(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT, &cfg)) {
       net.bind(rp);                 // re-bind after reconnect
       rpReady = true;
       // optionally re-start generator

--- a/examples/Wifi/PWMWifi/arduino_secrets.h
+++ b/examples/Wifi/PWMWifi/arduino_secrets.h
@@ -1,4 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
-#define SECRET_RP_IP IPAddress(192, 168, 0, 17)
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
 #define SECRET_RP_PORT 5000

--- a/examples/Wifi/README.md
+++ b/examples/Wifi/README.md
@@ -7,25 +7,25 @@
 ### Using the helper in your sketch
 
 1. Copy `wifiSCPI.h` and `wifiSCPI.cpp` into your sketch folder (or install them as a library).
-2. Create an `arduino_secrets.h` with your network credentials:
+2. Create an `arduino_secrets.h` with your WiFi credentials and Red Pitaya address:
 
    ```cpp
-   #define SECRET_SSID "your-ssid"
-   #define SECRET_PASS "your-password"
+   #define SECRET_SSID "NetworkName"
+   #define SECRET_PASS "Password"
+   #define SECRET_RP_IP IPAddress(x, x, x, x)
+   #define SECRET_RP_PORT 5000
    ```
-3. Include the headers and call `begin` with the Red Pitaya IP address and SCPI port:
+3. Include the headers and call `begin` with your Red Pitaya details:
 
    ```cpp
    #include "wifiSCPI.h"
    #include "arduino_secrets.h"
 
-   IPAddress rpIp(192, 168, 0, 17);   // update with your RP address
-   const uint16_t rpPort = 5000;      // SCPI port
    WifiSCPI rp;
 
    void setup() {
      Serial.begin(115200);
-     rp.begin(SECRET_SSID, SECRET_PASS, rpIp, rpPort);
+     rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
 
      rp.scpi("ACQ:RST");
      Serial.println(rp.scpiLine("*IDN?"));

--- a/examples/Wifi/SweepGenWifi/SweepGenWifi.ino
+++ b/examples/Wifi/SweepGenWifi/SweepGenWifi.ino
@@ -3,11 +3,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ------- User config -------
-IPAddress RP_IP(192, 168, 0, 17);   // your Red Pitaya IP
-const uint16_t RP_PORT = 5000;      // SCPI server port
 
 // Output amplitude/offset
 const float AMP_V  = 1.0;           // one-way amplitude (V)
@@ -46,7 +44,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -59,7 +57,7 @@ void loop() {
   // Optional keep-alive / auto-restart
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) startSweep();
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startSweep();
   }
   delay(500);
 }

--- a/examples/Wifi/SweepGenWifi/arduino_secrets.h
+++ b/examples/Wifi/SweepGenWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
+++ b/src/Wifi/2ChannelPhaseShiftWifi/2ChannelPhaseShiftWifi.ino
@@ -6,11 +6,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // -------- User config --------
-IPAddress RP_IP(192, 168, 0, 17);
-const uint16_t RP_PORT = 5000;
 
 const float FREQ_HZ   = 10000.0;  // both channels
 const float AMP_V     = 1.0;      // one-way amplitude
@@ -45,7 +43,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -58,7 +56,7 @@ void loop() {
   // Optional keep-alive / auto-restart
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) startTwoSineWithPhase();
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startTwoSineWithPhase();
   }
   delay(500);
 }

--- a/src/Wifi/2ChannelPhaseShiftWifi/arduino_secrets.h
+++ b/src/Wifi/2ChannelPhaseShiftWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AcquiireWifi/arduino_secrets.h
+++ b/src/Wifi/AcquiireWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AcquireNowRawWifi/AcquireNowRawWifi.ino
+++ b/src/Wifi/AcquireNowRawWifi/AcquireNowRawWifi.ino
@@ -2,10 +2,8 @@
    acquire_full_buffer_raw: force trigger and read full buffer as RAW ASCII codes
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -28,7 +26,7 @@ void printFirst(const String& blk, uint8_t n=12){
 void setup(){
   Serial.begin(115200);
   delay(200);
-  rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT);
+  rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
 
   rp.scpi("ACQ:RST");
   rp.scpi("ACQ:DEC:Factor 1");

--- a/src/Wifi/AcquireNowRawWifi/arduino_secrets.h
+++ b/src/Wifi/AcquireNowRawWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AcquireNowWifi/AcquireNowWifi.ino
+++ b/src/Wifi/AcquireNowWifi/AcquireNowWifi.ino
@@ -2,10 +2,8 @@
    acquire_trigger_now: force trigger and read CH1 (ASCII/VOLTS)
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -18,7 +16,7 @@ void printFirst(const String& blk, uint8_t n=12){
 
 void setup(){
   Serial.begin(115200); delay(200);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }

--- a/src/Wifi/AcquireNowWifi/arduino_secrets.h
+++ b/src/Wifi/AcquireNowWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
+++ b/src/Wifi/AcquireTriggerFromGenWifi/AcquireTriggerFromGenWifi.ino
@@ -5,10 +5,8 @@
    - fire generator INT trigger to produce the edge
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -21,7 +19,7 @@ void printFirst(const String& blk, uint8_t n=12){
 
 void setup(){
   Serial.begin(115200); delay(200);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }

--- a/src/Wifi/AcquireTriggerFromGenWifi/arduino_secrets.h
+++ b/src/Wifi/AcquireTriggerFromGenWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/AnalogReadWifi/AnalogReadWifi.ino
+++ b/src/Wifi/AnalogReadWifi/AnalogReadWifi.ino
@@ -5,10 +5,8 @@
 
 #include "wifiSCPI.h"
 #include <math.h>
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192, 168, 0, 17);
-const uint16_t RP_PORT = 5000;
 
 int   ARB_NPTS     = 2048;
 float F0_HZ        = 1000.0;
@@ -59,7 +57,7 @@ bool uploadSum3SinesOut1(int N) {
 void setup() {
   Serial.begin(115200);
   delay(150);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)) {
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)) {
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -70,7 +68,7 @@ void setup() {
 void loop() {
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) uploadSum3SinesOut1(ARB_NPTS);
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) uploadSum3SinesOut1(ARB_NPTS);
   }
   delay(500);
 }

--- a/src/Wifi/AnalogReadWifi/arduino_secrets.h
+++ b/src/Wifi/AnalogReadWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/ArbSignalWifi/ArbSignalWifi.ino
+++ b/src/Wifi/ArbSignalWifi/ArbSignalWifi.ino
@@ -6,12 +6,10 @@
 
 #include "wifiSCPI.h"
 #include <math.h>
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 /************ User Config ************/
 // Red Pitaya SCPI server
-IPAddress RP_IP(192, 168, 0, 17);
-const uint16_t RP_PORT = 5000;
 
 // ARB buffer size (use 2048 for speed; 16384 is the full period size)
 int   ARB_NPTS     = 2048;
@@ -87,7 +85,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -102,7 +100,7 @@ void loop() {
   // Keep the link healthy (optional)
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) uploadSum3SinesOut1(ARB_NPTS); // re-arm after reconnect
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) uploadSum3SinesOut1(ARB_NPTS); // re-arm after reconnect
   }
   delay(500);
 }

--- a/src/Wifi/ArbSignalWifi/arduino_secrets.h
+++ b/src/Wifi/ArbSignalWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/BurstSignalWifi/BurstSignalWifi.ino
+++ b/src/Wifi/BurstSignalWifi/BurstSignalWifi.ino
@@ -16,11 +16,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"  // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ---------- User config ----------
-IPAddress RP_IP(192, 168, 0, 17);   // your Red Pitaya IP
-const uint16_t RP_PORT = 5000;      // SCPI port
 
 // Signal settings
 const float FREQ_HZ   = 10e3;       // sine frequency
@@ -59,7 +57,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -72,7 +70,7 @@ void loop() {
   // Optional keep-alive
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) startBurst();
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startBurst();
   }
   delay(500);
 }

--- a/src/Wifi/BurstSignalWifi/arduino_secrets.h
+++ b/src/Wifi/BurstSignalWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/DMAAcquireWifi/DMAAcquireNowWifi.ino
+++ b/src/Wifi/DMAAcquireWifi/DMAAcquireNowWifi.ino
@@ -2,10 +2,8 @@
    dma/acquire_dma_trigger_now: set AXI DMA, trigger NOW, read 1024 samples near trig (ASCII)
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -19,7 +17,7 @@ void printFirst(const String& blk, uint8_t n=12){
 
 void setup(){
   Serial.begin(115200); delay(200);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }

--- a/src/Wifi/DMAAcquireWifi/DMAAcquireWifi.ino
+++ b/src/Wifi/DMAAcquireWifi/DMAAcquireWifi.ino
@@ -5,10 +5,8 @@
    - fire generator INT trigger to produce the edge
 */
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
-IPAddress RP_IP(192,168,0,17);
-const uint16_t RP_PORT = 5000;
 
 WifiSCPI rp;
 
@@ -21,7 +19,7 @@ void printFirst(const String& blk, uint8_t n=12){
 
 void setup(){
   Serial.begin(115200); delay(200);
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }

--- a/src/Wifi/DMAAcquireWifi/arduino_secrets.h
+++ b/src/Wifi/DMAAcquireWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/GPIOToggleWifi/GPIOToggleWifi.ino
+++ b/src/Wifi/GPIOToggleWifi/GPIOToggleWifi.ino
@@ -1,9 +1,7 @@
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"  // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ---------- User config ----------
-IPAddress RP_IP(192, 168, 0, 17);    // Red Pitaya IP
-const uint16_t RP_PORT = 5000;       // SCPI TCP port
 // ---------------------------------
 
 WifiSCPI rp;
@@ -16,7 +14,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -31,7 +29,7 @@ void setup() {
 void loop() {
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) {
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) {
       rp.scpi(String("DIG:PIN:DIR OUT,") + OUT_PIN);
       rp.scpi(String("DIG:PIN:DIR IN,")  + IN_PIN);
     }

--- a/src/Wifi/GPIOToggleWifi/arduino_secrets.h
+++ b/src/Wifi/GPIOToggleWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/GenSineWifi/GenSineWifi.ino
+++ b/src/Wifi/GenSineWifi/GenSineWifi.ino
@@ -3,11 +3,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ---------- User config ----------
-IPAddress RP_IP(192, 168, 0, 17);  // <-- your Red Pitaya IP
-const uint16_t RP_PORT = 5000;     // SCPI server port
 
 // Sine parameters
 const float SINE_FREQ_HZ = 2000.0; // frequency
@@ -32,7 +30,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -45,7 +43,7 @@ void setup() {
 void loop() {
   // Keep connection alive (optional)
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
-  if (!rp.connected()) rp.connectRP(RP_IP, RP_PORT);
+  if (!rp.connected()) rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT);
   delay(500);
 }
 

--- a/src/Wifi/GenSineWifi/arduino_secrets.h
+++ b/src/Wifi/GenSineWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/LEDsWifi/LEDsWifi.ino
+++ b/src/Wifi/LEDsWifi/LEDsWifi.ino
@@ -1,9 +1,7 @@
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ------- User config -------
-IPAddress RP_IP(192, 168, 0, 17);
-const uint16_t RP_PORT = 5000;
 
 const float GEN_FREQ_HZ   = 2000.0;
 const float GEN_AMPL_V    = 1.0;
@@ -27,7 +25,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -38,7 +36,7 @@ void setup() {
 void loop() {
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) startGen();
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startGen();
   }
   delay(500);
 }

--- a/src/Wifi/LEDsWifi/arduino_secrets.h
+++ b/src/Wifi/LEDsWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/PWMWifi/PWMWifi.ino
+++ b/src/Wifi/PWMWifi/PWMWifi.ino
@@ -4,11 +4,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ----- User config -----
-IPAddress RP_IP(192, 168, 0, 17);  // Red Pitaya IP
-const uint16_t RP_PORT = 5000;     // SCPI port
 
 const float PWM_FREQ_HZ = 1000.0;  // PWM frequency (Hz)
 const float PWM_DUTY    = 0.30;    // 30% duty (ratio 0..1)
@@ -34,7 +32,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -47,7 +45,7 @@ void loop() {
   // Optional keep-alive / auto-restart
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) startPWM();
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startPWM();
   }
   delay(500);
 }

--- a/src/Wifi/PWMWifi/arduino_secrets.h
+++ b/src/Wifi/PWMWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000

--- a/src/Wifi/README.md
+++ b/src/Wifi/README.md
@@ -7,25 +7,25 @@
 ### Using the helper in your sketch
 
 1. Copy `wifiSCPI.h` and `wifiSCPI.cpp` into your sketch folder (or install them as a library).
-2. Create an `arduino_secrets.h` with your network credentials:
+2. Create an `arduino_secrets.h` with your WiFi credentials and Red Pitaya address:
 
    ```cpp
-   #define SECRET_SSID "your-ssid"
-   #define SECRET_PASS "your-password"
+   #define SECRET_SSID "NetworkName"
+   #define SECRET_PASS "Password"
+   #define SECRET_RP_IP IPAddress(x, x, x, x)
+   #define SECRET_RP_PORT 5000
    ```
-3. Include the headers and call `begin` with the Red Pitaya IP address and SCPI port:
+3. Include the headers and call `begin` with your Red Pitaya details:
 
    ```cpp
    #include "wifiSCPI.h"
    #include "arduino_secrets.h"
 
-   IPAddress rpIp(192, 168, 0, 17);   // update with your RP address
-   const uint16_t rpPort = 5000;      // SCPI port
    WifiSCPI rp;
 
    void setup() {
      Serial.begin(115200);
-     rp.begin(SECRET_SSID, SECRET_PASS, rpIp, rpPort);
+     rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT);
 
      rp.scpi("ACQ:RST");
      Serial.println(rp.scpiLine("*IDN?"));

--- a/src/Wifi/SweepGenWifi/SweepGenWifi.ino
+++ b/src/Wifi/SweepGenWifi/SweepGenWifi.ino
@@ -3,11 +3,9 @@
 */
 
 #include "wifiSCPI.h"
-#include "arduino_secrets.h"   // SECRET_SSID, SECRET_PASS
+#include "arduino_secrets.h"   // WiFi + Red Pitaya settings
 
 // ------- User config -------
-IPAddress RP_IP(192, 168, 0, 17);   // your Red Pitaya IP
-const uint16_t RP_PORT = 5000;      // SCPI server port
 
 // Output amplitude/offset
 const float AMP_V  = 1.0;           // one-way amplitude (V)
@@ -46,7 +44,7 @@ void setup() {
   Serial.begin(115200);
   delay(150);
 
-  if(!rp.begin(SECRET_SSID, SECRET_PASS, RP_IP, RP_PORT)){
+  if(!rp.begin(SECRET_SSID, SECRET_PASS, SECRET_RP_IP, SECRET_RP_PORT)){
     Serial.println(F("Failed to connect"));
     while(true){}
   }
@@ -59,7 +57,7 @@ void loop() {
   // Optional keep-alive / auto-restart
   if (WiFi.status() != WL_CONNECTED) rp.connectWiFi(SECRET_SSID, SECRET_PASS);
   if (!rp.connected()) {
-    if (rp.connectRP(RP_IP, RP_PORT)) startSweep();
+    if (rp.connectRP(SECRET_RP_IP, SECRET_RP_PORT)) startSweep();
   }
   delay(500);
 }

--- a/src/Wifi/SweepGenWifi/arduino_secrets.h
+++ b/src/Wifi/SweepGenWifi/arduino_secrets.h
@@ -1,2 +1,4 @@
-#define SECRET_SSID "Pokemoni"
-#define SECRET_PASS "kotejebe123"
+#define SECRET_SSID "NetworkName"
+#define SECRET_PASS "Password"
+#define SECRET_RP_IP IPAddress(x, x, x, x)
+#define SECRET_RP_PORT 5000


### PR DESCRIPTION
## Summary
- Load WiFi and Red Pitaya connection data from `arduino_secrets.h`
- Replace hard-coded RP_IP/RP_PORT with `SECRET_RP_IP` and `SECRET_RP_PORT` in all WiFi sketches
- Document secret macros in WiFi README

## Testing
- `arduino-cli compile examples/Wifi/LEDsWifi/LEDsWifi.ino` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 error)*


------
https://chatgpt.com/codex/tasks/task_e_68a64feaad1c83258a003c7d3edb0a61